### PR TITLE
Commit IDEWorkspaceChecks.plist file according to Apple's recommendation

### DIFF
--- a/SnowplowIgluClient.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SnowplowIgluClient.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Small change to commit a file that Xcode now creates when you open the repo in Xcode 9.3+, so the workspace stays clean.

This is the same change as in [this issue on the snowplow tracker](https://github.com/snowplow/snowplow-objc-tracker/issues/354) and [associated pull request](https://github.com/snowplow/snowplow-objc-tracker/pull/355).
